### PR TITLE
WIP: Add FromRow and ToRow instances for Data.List.NonEmpty

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromRow.hs
+++ b/src/Database/PostgreSQL/Simple/FromRow.hs
@@ -36,6 +36,8 @@ import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Class
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import           Database.PostgreSQL.Simple.Types (Only(..))
@@ -449,6 +451,11 @@ instance FromField a => FromRow [a] where
     fromRow = do
       n <- numFieldsRemaining
       replicateM n field
+
+instance (FromField a) => FromRow (NonEmpty a) where
+    fromRow = do
+      n <- numFieldsRemaining
+      NE.fromList <$> replicateM n field
 
 instance FromField a => FromRow (Maybe [a]) where
     fromRow = do

--- a/src/Database/PostgreSQL/Simple/ToRow.hs
+++ b/src/Database/PostgreSQL/Simple/ToRow.hs
@@ -21,6 +21,9 @@ module Database.PostgreSQL.Simple.ToRow
       ToRow(..)
     ) where
 
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+
 import Database.PostgreSQL.Simple.ToField (Action(..), ToField(..))
 import Database.PostgreSQL.Simple.Types (Only(..), (:.)(..))
 import GHC.Generics
@@ -197,6 +200,9 @@ instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f,
 
 instance (ToField a) => ToRow [a] where
     toRow = map toField
+
+instance (ToField a) => ToRow (NonEmpty a) where
+    toRow = map toField . NE.toList
 
 instance (ToRow a, ToRow b) => ToRow (a :. b) where
     toRow (a :. b) = toRow a ++ toRow b


### PR DESCRIPTION
This PR adds support for `NonEmpty` to `ToRow` and `FromRow`.

cc @phadej 