### PR TITLE
Export GFromRow and GToRow for use as constraints

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromRow.hs
+++ b/src/Database/PostgreSQL/Simple/FromRow.hs
@@ -26,6 +26,7 @@ module Database.PostgreSQL.Simple.FromRow
      , field
      , fieldWith
      , numFieldsRemaining
+     , GFromRow
      ) where
 
 import           Prelude hiding (null)

--- a/src/Database/PostgreSQL/Simple/ToRow.hs
+++ b/src/Database/PostgreSQL/Simple/ToRow.hs
@@ -19,6 +19,7 @@
 module Database.PostgreSQL.Simple.ToRow
     (
       ToRow(..)
+    , GToRow
     ) where
 
 import Database.PostgreSQL.Simple.ToField (Action(..), ToField(..))


### PR DESCRIPTION
This is useful for generalizing over things which can have their `FromRow` and `ToRow` instances derived. Specifically, this would enable libraries like [generic-override](https://github.com/estatico/generic-override) to be able to interop with `postgresql-simple`'s generic machinery.

-------------------------------------

Without this change, given the following code -

```haskell
instance (Generic (Override a xs)) => ToRow (Override a xs)
```

We'll get the following compiler error -

```
Could not deduce (Database.PostgreSQL.Simple.ToRow.GToRow
                          (Data.Override.Internal.OverrideRep
                             Data.Override.Internal.EmptyInspect xs (Rep a)))
        arising from a use of ‘Database.PostgreSQL.Simple.ToRow.$dmtoRow’
```

This can be easily fixed by adding the `GToRow` constraint -

```haskell
instance (Generic (Override a xs), GToRow (Override a xs)) => ToRow (Override a xs)
```

However, this can't be done unless the constraint itself is exported.