### PR TITLE
feat: add superclass for all postgresql exceptions

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -154,6 +154,7 @@ test-suite test
     Serializable
     Time
     Interval
+    Exception
 
   ghc-options:        -threaded
   ghc-options:        -Wall -fno-warn-name-shadowing -fno-warn-unused-do-bind

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -64,6 +64,7 @@ module Database.PostgreSQL.Simple
     , Only(..)
     , (:.)(..)
     -- ** Exceptions
+    , SomePostgreSqlException(..)
     , SqlError(..)
     , PQ.ExecStatus(..)
     , FormatError(..)

--- a/src/Database/PostgreSQL/Simple/Errors.hs
+++ b/src/Database/PostgreSQL/Simple/Errors.hs
@@ -60,7 +60,9 @@ data ConstraintViolation
    deriving (Show, Eq, Ord, Typeable)
 
 -- Default instance should be enough
-instance Exception ConstraintViolation
+instance Exception ConstraintViolation where
+  toException = postgresqlExceptionToException
+  fromException = postgresqlExceptionFromException
 
 
 -- | Tries to convert 'SqlError' to 'ConstrainViolation', checks sqlState and

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -118,7 +118,7 @@ module Database.PostgreSQL.Simple.FromField
 
 import           Control.Applicative ( Const(Const), (<|>), (<$>), pure, (*>), (<*) )
 import           Control.Concurrent.MVar (MVar, newMVar)
-import           Control.Exception (Exception)
+import           Control.Exception (Exception (toException, fromException))
 import qualified Data.Aeson as JSON
 import qualified Data.Aeson.Internal as JSON
 import qualified Data.Aeson.Parser as JSON (value')
@@ -182,7 +182,9 @@ data ResultError = Incompatible { errSQLType :: String
                  -- between metadata and actual data in a row).
                    deriving (Eq, Show, Typeable)
 
-instance Exception ResultError
+instance Exception ResultError where
+  toException = postgresqlExceptionToException
+  fromException = postgresqlExceptionFromException
 
 left :: Exception a => a -> Conversion b
 left = conversionError

--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -100,12 +100,8 @@ instance Show SomePostgreSqlException where
   showsPrec :: Int -> SomePostgreSqlException -> ShowS
   showsPrec p (SomePostgreSqlException e) = showsPrec p e
 
-#if __GLASGOW_HASKELL__ >= 7103
 instance Exception SomePostgreSqlException where
   displayException (SomePostgreSqlException e) = displayException e
-#else
-instance Exception SomePostgreSqlException
-#endif
 
 data SqlError = SqlError {
      sqlState       :: ByteString

--- a/test/Exception.hs
+++ b/test/Exception.hs
@@ -8,11 +8,9 @@ import Database.PostgreSQL.Simple
 import Test.Tasty.HUnit (Assertion, assertBool)
 import Common (TestEnv)
 import Control.Exception (Exception (..), SomeException)
-import Data.Maybe ( isJust )
-#if __GLASGOW_HASKELL__ >= 7103
+import Data.Maybe (isJust)
 import Data.Either (isLeft)
 import Control.Exception (throwIO, try)
-#endif
 
 testExceptions :: TestEnv -> Assertion
 testExceptions _ = do
@@ -26,12 +24,10 @@ testExceptions _ = do
   let sqlEx :: SomeException = toException sqlError
   assertBool "SqlError is SomePostgreSqlException" $ isJust (fromException sqlEx :: Maybe SomePostgreSqlException)
   assertBool "SqlError is SqlError" $ isJust (fromException sqlEx :: Maybe SqlError)
-#if __GLASGOW_HASKELL__ >= 7103
   eSqlError :: Either SqlError () <- try $ throwIO sqlEx
   assertBool "Can catch SqlError" $ isLeft eSqlError
   eSqlPostgreSqlEx :: Either SomePostgreSqlException () <- try $ throwIO sqlEx
   assertBool "Can catch SomePostgreSqlException from SqlError" $ isLeft eSqlPostgreSqlEx
-#endif
 
   let formatError = FormatError 
         { fmtMessage = ""
@@ -41,12 +37,10 @@ testExceptions _ = do
   let formatEx :: SomeException = toException formatError
   assertBool "FormatError is SomePostgreSqlException" $ isJust (fromException formatEx :: Maybe SomePostgreSqlException)
   assertBool "FormatError is FormatError" $ isJust (fromException formatEx :: Maybe FormatError)
-#if __GLASGOW_HASKELL__ >= 7103
   eFormatError :: Either FormatError () <- try $ throwIO formatEx
   assertBool "Can catch FormatError" $ isLeft eFormatError
   eFormatPostreSqlEx :: Either SomePostgreSqlException () <- try $ throwIO formatEx
   assertBool "Can catch SomePostgreSqlException from FormatError" $ isLeft eFormatPostreSqlEx
-#endif
   
   let queryError = QueryError 
           { qeMessage = ""
@@ -55,12 +49,10 @@ testExceptions _ = do
   let queryEx :: SomeException = toException queryError
   assertBool "QueryError is SomePostgreSqlException" $ isJust (fromException queryEx :: Maybe SomePostgreSqlException)
   assertBool "QueryError is QueryError" $ isJust (fromException queryEx :: Maybe QueryError)
-#if __GLASGOW_HASKELL__ >= 7103
   eQueryError :: Either QueryError () <- try $ throwIO queryEx
   assertBool "Can catch QueryError" $ isLeft eQueryError
   eQueryPostgreSqlEx :: Either SomePostgreSqlException () <- try $ throwIO queryEx
   assertBool "Can catch SomePostgreSqlException from QueryError" $ isLeft eQueryPostgreSqlEx
-#endif
   
   let resultError = Incompatible 
         { errSQLType = ""
@@ -72,10 +64,7 @@ testExceptions _ = do
   let resultEx :: SomeException = toException resultError
   assertBool "ResultError is SomePostgreSqlException" $ isJust (fromException resultEx :: Maybe SomePostgreSqlException)
   assertBool "ResultError is ResultError" $ isJust (fromException resultEx :: Maybe ResultError)
-#if __GLASGOW_HASKELL__ >= 7103 
   eResultEx :: Either ResultError () <- try $ throwIO resultEx 
   assertBool "Can catch ResultError" $ isLeft eResultEx 
   eResultPostgreSqlEx :: Either SomePostgreSqlException () <- try $ throwIO resultEx
   assertBool "Can catch SomePostgreSqlException from ResultError" $ isLeft eResultPostgreSqlEx
-#endif
-

--- a/test/Exception.hs
+++ b/test/Exception.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Exception (testExceptions) where
+
+import Database.PostgreSQL.Simple
+import Test.Tasty.HUnit (Assertion, assertBool)
+import Common (TestEnv)
+import Control.Exception (Exception (..), SomeException)
+import Data.Maybe ( isJust )
+
+testExceptions :: TestEnv -> Assertion
+testExceptions _ = do
+  let sqlError :: SomeException 
+        = toException $ SqlError 
+        { sqlState       = ""
+        , sqlExecStatus  = FatalError
+        , sqlErrorMsg    = ""
+        , sqlErrorDetail = ""
+        , sqlErrorHint   = ""
+        }
+  assertBool "SqlError is SomepostgreSqlException" $ isJust (fromException sqlError :: Maybe SomePostgreSqlException)
+  assertBool "SqlError is SqlError" $ isJust (fromException sqlError :: Maybe SqlError)
+  
+  let formatError :: SomeException 
+        = toException $ FormatError 
+        { fmtMessage = ""
+        , fmtQuery = ""
+        , fmtParams = []
+        }
+  assertBool "FormatError is SomepostgreSqlException" $ isJust (fromException formatError :: Maybe SomePostgreSqlException)
+  assertBool "FormatError is FormatError" $ isJust (fromException formatError :: Maybe FormatError)
+
+  let queryError :: SomeException 
+        = toException $ QueryError 
+        { qeMessage = ""
+        , qeQuery = ""
+        }
+  assertBool "QueryError is SomepostgreSqlException" $ isJust (fromException queryError :: Maybe SomePostgreSqlException)
+  assertBool "QueryError is QueryError" $ isJust (fromException queryError :: Maybe QueryError)
+  
+  let resultError :: SomeException
+        = toException $ Incompatible 
+        { errSQLType = ""
+        , errSQLTableOid = Nothing
+        , errSQLField = ""
+        , errHaskellType = ""
+        , errMessage = ""
+        }
+  assertBool "ResultError is SomepostgreSqlException" $ isJust (fromException resultError :: Maybe SomePostgreSqlException)
+  assertBool "ResultError is ResultError" $ isJust (fromException resultError :: Maybe ResultError)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -55,6 +55,7 @@ import Notify
 import Serializable
 import Time
 import Interval
+import Exception (testExceptions)
 
 tests :: TestEnv -> TestTree
 tests env = testGroup "tests"
@@ -84,6 +85,7 @@ tests env = testGroup "tests"
     , testCase "2-ary generic"        . testGeneric2
     , testCase "3-ary generic"        . testGeneric3
     , testCase "Timeout"              . testTimeout
+    , testCase "Exceptions"           . testExceptions
     ]
 
 testBytea :: TestEnv -> TestTree


### PR DESCRIPTION
This adds a common superclass `SomePostgreSqlException` for all four `Exception` types:

* `SqlError`
* `FormatError`
* `QueryError`
* `ResultError`

The benefit is that clients can call `fromException` to handle all postgresql-simple exceptions (see `isPostgreSqlException` in `test/Exception.hs`), rather than being forced to handle all `SomeException`s.

Without `SomePostgreSqlException`, clients have to check whether a caught `SomeException` is one of the 4 postgresql-simple exceptions. This is error-prone, as the addition of a new type of exception to this library would go unnoticed.

This change is backward-compatible.

Note: I ran stylish-haskell, but it formatted many files that I hadn't touched. So instead, I manually formatted my changes.
