### PR TITLE
Fail to parse values if inside function.

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -154,6 +154,7 @@ test-suite test
     Serializable
     Time
     Interval
+    ParsingTemplate
 
   ghc-options:        -threaded
   ghc-options:        -Wall -fno-warn-name-shadowing -fno-warn-unused-do-bind

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -117,6 +117,7 @@ module Database.PostgreSQL.Simple
     -- * Helper functions
     , formatMany
     , formatQuery
+    , parseTemplate
     ) where
 
 import           Data.ByteString.Builder (Builder, byteString, char8)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -55,35 +55,38 @@ import Notify
 import Serializable
 import Time
 import Interval
+import ParsingTemplate
 
 tests :: TestEnv -> TestTree
 tests env = testGroup "tests"
     $ map ($ env)
-    [ testBytea
-    , testCase "ExecuteMany"          . testExecuteMany
-    , testCase "Fold"                 . testFold
-    , testCase "Notify"               . testNotify
-    , testCase "Serializable"         . testSerializable
-    , testCase "Time"                 . testTime
-    , testCase "Interval"             . testInterval
-    , testCase "Array"                . testArray
-    , testCase "Array of nullables"   . testNullableArray
-    , testCase "HStore"               . testHStore
-    , testCase "citext"               . testCIText
-    , testCase "JSON"                 . testJSON
-    , testCase "Aeson newtype"        . testAeson
-    , testCase "DerivingVia"          . testDerivingVia
-    , testCase "Question mark escape" . testQM
-    , testCase "Savepoint"            . testSavepoint
-    , testCase "Unicode"              . testUnicode
-    , testCase "Values"               . testValues
-    , testCase "Copy"                 . testCopy
-    , testCopyFailures
-    , testCase "Double"               . testDouble
-    , testCase "1-ary generic"        . testGeneric1
-    , testCase "2-ary generic"        . testGeneric2
-    , testCase "3-ary generic"        . testGeneric3
-    , testCase "Timeout"              . testTimeout
+    [
+    --  testBytea
+    --, testCase "ExecuteMany"          . testExecuteMany
+    --, testCase "Fold"                 . testFold
+    --, testCase "Notify"               . testNotify
+    --, testCase "Serializable"         . testSerializable
+    --, testCase "Time"                 . testTime
+    --, testCase "Interval"             . testInterval
+    --, testCase "Array"                . testArray
+    --, testCase "Array of nullables"   . testNullableArray
+    --, testCase "HStore"               . testHStore
+    --, testCase "citext"               . testCIText
+    --, testCase "JSON"                 . testJSON
+    --, testCase "Aeson newtype"        . testAeson
+    --, testCase "DerivingVia"          . testDerivingVia
+    --, testCase "Question mark escape" . testQM
+    --, testCase "Savepoint"            . testSavepoint
+    --, testCase "Unicode"              . testUnicode
+    --, testCase "Values"               . testValues
+    --, testCase "Copy"                 . testCopy
+    --, testCopyFailures
+    --, testCase "Double"               . testDouble
+    --, testCase "1-ary generic"        . testGeneric1
+    --, testCase "2-ary generic"        . testGeneric2
+    --, testCase "3-ary generic"        . testGeneric3
+    --, testCase "Timeout"              . testTimeout
+      testCase "Parsing template"     . testParsingTemplate
     ]
 
 testBytea :: TestEnv -> TestTree

--- a/test/ParsingTemplate.hs
+++ b/test/ParsingTemplate.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ParsingTemplate (testParsingTemplate) where
+
+import Common
+import Test.Tasty.HUnit (assertBool, assertEqual)
+import Database.PostgreSQL.Simple (parseTemplate)
+
+testParsingTemplate :: TestEnv -> Assertion
+testParsingTemplate env@TestEnv{..} = do
+  assertEqual "" (Just ("values ","(?, ?)","")) (parseTemplate "values (?, ?)")
+  assertEqual "" (Just ("values ","(?, X(?))","")) (parseTemplate "values (?, X(?))")


### PR DESCRIPTION
If given a query like to `returning`

```sql
INSERT INTO a (b, c) VALUES (?, X(?))
```

It will fail to parse the template and no arguments are sent correctly.

```txt
cabal v2-test
Build profile: -w ghc-9.0.2 -O1
In order, the following will be built (use -v for more details):
 - Sdk-0.0.1 (test:SdkTests) (first run)
Preprocessing test suite 'SdkTests' for Sdk-0.0.1..
Building test suite 'SdkTests' for Sdk-0.0.1..
Running 1 test suites...
Test suite SdkTests: RUNNING...
### Error in:   Sdk:1:a test       
FormatError {
  fmtMessage = "syntax error in multi-row template", 
  fmtQuery = "INSERT INTO a (b, c) VALUES (?, DATE_TRUNC('seconds', ?)) RETURNING id, b, c", 
  fmtParams = []
}
Cases: 2  Tried: 2  Errors: 1  Failures: 0

Test suite SdkTests: FAIL
Test suite logged to:
/usr/local/src/source/sdk/dist-newstyle/build/x86_64-linux/ghc-9.0.2/Sdk-0.0.1/t/SdkTests/test/Sdk-0.0.1-SdkTests.log
0 of 1 test suites (0 of 1 test cases) passed.
cabal: Tests failed for test:SdkTests from Sdk-0.0.1.
```