### PR TITLE
Avoid dependency on obsolete bytestring-builder package if possible

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -82,7 +82,7 @@ library
   -- GHC bundled libs
   build-depends:
       base              >=4.6.0.0  && <4.19
-    , bytestring        >=0.10.0.0 && <0.12
+    , bytestring        >=0.10.4   && <0.12
     , containers        >=0.5.0.0  && <0.7
     , template-haskell  >=2.8.0.0  && <2.21
     , text              >=1.2.3.0  && <1.3 || >=2.0 && <2.1
@@ -93,7 +93,6 @@ library
   build-depends:
       aeson               >=1.4.1.0    && <1.6 || >=2.0.0.0 && <2.3
     , attoparsec          >=0.13.2.2   && <0.15
-    , bytestring-builder  >=0.10.8.1.0 && <0.11
     , case-insensitive    >=1.2.0.11   && <1.3
     , hashable            >=1.2.7.0    && <1.5
     , Only                >=0.1        && <0.1.1


### PR DESCRIPTION
`bytestring-builder` is required only when building with versions of `bytestring` older than 0.10.4. This commit adds conditional logic to avoid the dependency on the obsolete package in that case.