### PR TITLE
Move returning functions into their own section in export list

### DIFF
--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -108,11 +108,9 @@ module Database.PostgreSQL.Simple
     -- * Modifications that return results
     , returning
     , returningWith
---    , Base.insertID
     -- * Transaction handling
     , withTransaction
     , withSavepoint
---    , Base.autocommit
     , begin
     , commit
     , rollback

--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -94,7 +94,6 @@ module Database.PostgreSQL.Simple
     , foldWithOptions_
     , forEach
     , forEach_
-    , returning
     -- ** Queries that stream results taking a parser as an argument
     , foldWith
     , foldWithOptionsAndParser
@@ -102,11 +101,13 @@ module Database.PostgreSQL.Simple
     , foldWithOptionsAndParser_
     , forEachWith
     , forEachWith_
-    , returningWith
     -- * Statements that do not return results
     , execute
     , execute_
     , executeMany
+    -- * Modifications that return results
+    , returning
+    , returningWith
 --    , Base.insertID
     -- * Transaction handling
     , withTransaction

--- a/src/Database/PostgreSQL/Simple/Transaction.hs
+++ b/src/Database/PostgreSQL/Simple/Transaction.hs
@@ -25,7 +25,6 @@ module Database.PostgreSQL.Simple.Transaction
     , defaultTransactionMode
     , defaultIsolationLevel
     , defaultReadWriteMode
---    , Base.autocommit
     , begin
     , beginLevel
     , beginMode


### PR DESCRIPTION
For some reason the `returning` functions are currently at the ends of the streaming sections. As far as I can tell they do not stream results. This PR moves them to their own section with the section name cribbed from the overview.