### PR TITLE
Single row mode streaming

### DIFF
--- a/src/Database/PostgreSQL/Simple/Copy.hs
+++ b/src/Database/PostgreSQL/Simple/Copy.hs
@@ -261,9 +261,3 @@ getCopyCommandTag funcName pqconn = do
     errCmdStatusFmt = B.unpack funcName ++ ": failed to parse command status"
 
 
-consumeResults :: PQ.Connection -> IO ()
-consumeResults pqconn = do
-    mres <- PQ.getResult pqconn
-    case mres of
-      Nothing -> return ()
-      Just _  -> consumeResults pqconn

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -221,7 +221,11 @@ class FromField a where
 --   finally query the database's meta-schema.
 
 typename :: Field -> Conversion ByteString
-typename field = typname <$> typeInfo field
+typename field = Conversion $ \conn -> do
+  status <- PQ.resultStatus (result field)
+  case status of
+    PQ.SingleTuple -> pure (Ok "unknown type")
+    _              -> runConversion (typname <$> typeInfo field) conn
 
 typeInfo :: Field -> Conversion TypeInfo
 typeInfo Field{..} = Conversion $ \conn -> do

--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -635,3 +635,10 @@ breakOnSingleQuestionMark b = go (B8.empty, b)
                 go2 ('?', t2) = go (noQ `B8.snoc` '?',t2)
                 -- Anything else means
                 go2 _ = tup
+
+consumeResults :: PQ.Connection -> IO ()
+consumeResults pqconn = do
+    mres <- PQ.getResult pqconn
+    case mres of
+      Nothing -> return ()
+      Just _  -> consumeResults pqconn


### PR DESCRIPTION
This adds a version of `foldWith` that uses [single row mode](https://www.postgresql.org/docs/current/static/libpq-single-row-mode.html) instead of a cursor under the hood.

The main benefit is that queries show up as themselves in logs and pg_stat_statements and the like (c.f., #100).

This PR doesn't yet define `foldSingleRowMode` and `foldSingleRowMode_` (the versions using `FromRow` rather than an explicit parser). I'd be happy to add them or instead add a `SingleRowMode` constructor to `FoldOptions`. (Mild preference for the extra functions.)