### PR TITLE
GHC 9.10 support

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231110
+# version: 0.19.20240702
 #
-# REGENDATA ("0.17.20231110",["github","cabal.project"])
+# REGENDATA ("0.19.20240702",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     services:
       postgres:
         image: postgres:14
@@ -38,6 +38,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.1
             compilerKind: ghc
             compilerVersion: 9.8.1
@@ -71,12 +76,12 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
@@ -84,21 +89,11 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -110,22 +105,13 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -182,7 +168,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -209,9 +195,12 @@ jobs:
           echo "package postgresql-simple" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
-          allow-newer: cryptohash-md5-0.11.100.1:base
+          source-repository-package
+            type:     git
+            location: https://github.com/haskellari/postgresql-libpq.git
+            tag:      714790537b783cd78741ab0762188a0ebbec8d4e
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(postgresql-simple)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(postgresql-simple)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -219,7 +208,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -249,7 +238,7 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,3 @@
 packages: .
 tests: true
 
-source-repository-package
-  type: git
-  location: https://github.com/haskellari/postgresql-libpq.git
-  tag: 714790537b783cd78741ab0762188a0ebbec8d4e
-

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,8 @@
 packages: .
 tests: true
 
-allow-newer: cryptohash-md5-0.11.100.1:base
+source-repository-package
+  type: git
+  location: https://github.com/haskellari/postgresql-libpq.git
+  tag: 714790537b783cd78741ab0762188a0ebbec8d4e
+

--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -78,7 +78,7 @@ library
 
   -- GHC bundled libs
   build-depends:
-      base              >=4.12.0.0 && <4.22
+      base              >=4.12.0.0 && <4.21
     , bytestring        >=0.10.8.2 && <0.13
     , containers        >=0.6.0.1  && <0.8
     , template-haskell  >=2.14.0.0 && <2.23

--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -32,6 +32,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.3
    || ==9.8.1
+   || ==9.10.1
 
 library
   default-language:   Haskell2010
@@ -77,10 +78,10 @@ library
 
   -- GHC bundled libs
   build-depends:
-      base              >=4.12.0.0 && <4.20
+      base              >=4.12.0.0 && <4.22
     , bytestring        >=0.10.8.2 && <0.13
-    , containers        >=0.6.0.1  && <0.7
-    , template-haskell  >=2.14.0.0 && <2.22
+    , containers        >=0.6.0.1  && <0.8
+    , template-haskell  >=2.14.0.0 && <2.23
     , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
     , time-compat       >=1.9.5    && <1.12
     , transformers      >=0.5.6.2  && <0.7
@@ -90,7 +91,7 @@ library
       aeson             >=2.1.2.1  && <2.3
     , attoparsec        >=0.14.4   && <0.15
     , case-insensitive  >=1.2.1.0  && <1.3
-    , hashable          >=1.4.3.0  && <1.5
+    , hashable          >=1.4.3.0  && <1.6
     , Only              >=0.1      && <0.1.1
     , postgresql-libpq  >=0.10.0.0 && <0.11
     , scientific        >=0.3.7.0  && <0.4


### PR DESCRIPTION
I know there is issue #139, so adding this as a draft so that once everything is ready hopefully this helps with the last few required changes.

I think the blockers for https://github.com/haskellari/postgresql-libpq/issues/60 are sorted
E.g. [inspection-testing]( https://github.com/nomeata/inspection-testing/pull/78) fixed today with a hackage metadata release

What I've done here is
- Update the CI template (for 9.10.1)
- Updated bounds (`cabal outdated` reports nothing now)
- Removed the `cabal.project` newer entry for `cryptohash`
- Added a temporary `cabal.project` entry for `postgresql-libpq:9.10` just to prove that it all works. Once that is merged this should obviously be removed.

Hope this helps