### PR TITLE
Parenthesize negative numbers in `ToField` instances

### DIFF
--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -32,6 +32,7 @@ import           Data.ByteString.Builder
                    , wordDec, word8Dec, word16Dec, word32Dec, word64Dec
                    , floatDec, doubleDec
                    )
+import           Data.ByteString.Builder.Scientific (scientificBuilder)
 import Data.Functor.Identity (Identity(Identity))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
@@ -51,7 +52,6 @@ import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as ST
 import qualified Data.Text.Encoding as ST
 import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Builder as LT
 import           Data.UUID.Types   (UUID)
 import qualified Data.UUID.Types as UUID
 import           Data.Vector (Vector)
@@ -59,7 +59,6 @@ import qualified Data.Vector as V
 import qualified Database.PostgreSQL.LibPQ as PQ
 import           Database.PostgreSQL.Simple.Time
 import           Data.Scientific (Scientific)
-import           Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import           Foreign.C.Types (CUInt(..))
 
 -- | How to render an element when substituting it into a query.
@@ -195,7 +194,7 @@ instance ToField Double where
     {-# INLINE toField #-}
 
 instance ToField Scientific where
-    toField x = toField (LT.toLazyText (scientificBuilder x))
+    toField = Plain . scientificBuilder
     {-# INLINE toField #-}
 
 instance ToField (Binary SB.ByteString) where


### PR DESCRIPTION
Closes #143.

This also switches the `Scientific` instance to use a `ByteString` builder instead of a `Text.Lazy` builder. Lazy text dates back to 87135c1, when scientific-0.2.0.2 only provided that option. Now we require scientific >= 0.3.7.0, which also provides the `ByteString` builder. The alternative was to reimplement `parenNegatives` for this instance, which also wouldn't be too bad.

For types with signed zeros, `-0` isn't parenthesized. I wasn't sure how to detect it ("check whether the rendered value starts with `-`" should work but breaking out of `Builder` feels bad for performance?), and I'm not aware of any situation where `-(0::type)` would be different than `(-0)::type`. I could easily imagine I'm missing something though.