### PR TITLE
provide `FromJSON ConnectInfo` instance for easy configuration

### DIFF
--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE  CPP, BangPatterns, DoAndIfThenElse, RecordWildCards  #-}
 {-# LANGUAGE  DeriveDataTypeable, DeriveGeneric                    #-}
 {-# LANGUAGE  GeneralizedNewtypeDeriving                           #-}
+{-# LANGUAGE  DeriveAnyClass #-}
 {-# LANGUAGE  ExistentialQuantification                            #-}
 {-# LANGUAGE  InstanceSigs                                         #-}
 
@@ -27,6 +28,7 @@ import           Control.Applicative
 import           Control.Exception
 import           Control.Concurrent.MVar
 import           Control.Monad(MonadPlus(..))
+import           Data.Aeson (FromJSON)
 import           Data.ByteString(ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
@@ -148,7 +150,7 @@ data ConnectInfo = ConnectInfo {
     , connectUser :: String
     , connectPassword :: String
     , connectDatabase :: String
-    } deriving (Generic,Eq,Read,Show,Typeable)
+    } deriving (Generic,Eq,Read,Show,Typeable,FromJSON)
 
 -- | Default information for setting up a connection.
 --


### PR DESCRIPTION
I think it would be helpful to provide instance `FromJSON ConnectInfo` for reading `ConnectInfo` from JSON or YAML.

i.e. via `loadYamlSettings`: https://hackage.haskell.org/package/yaml-0.11.11.2/docs/Data-Yaml-Config.html#v:loadYamlSettings 