### PR TITLE
redact password from `Show ConnectInfo`

### DIFF
--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -148,7 +148,18 @@ data ConnectInfo = ConnectInfo {
     , connectUser :: String
     , connectPassword :: String
     , connectDatabase :: String
-    } deriving (Generic,Eq,Read,Show,Typeable)
+    } deriving (Generic,Eq,Read,Typeable)
+
+data ConnectInfoRedacted = ConnectInfoRedacted {
+      connectRedactedHost :: String
+    , connectRedactedPort :: Word16
+    , connectRedactedUser :: String
+    , connectRedactedDatabase :: String
+    } deriving Show
+
+instance Show ConnectInfo where
+  show x = show $
+    ConnectInfoRedacted (connectHost x) (connectPort x) (connectUser x) (connectDatabase x)
 
 -- | Default information for setting up a connection.
 --


### PR DESCRIPTION
This should redact the password when `ConnectInfo` is printed.

Here is a test with password `"foo"`:
```
ghci> x = ConnectInfo "1" (read "1") "1" "foo" "1"

ghci> x
ConnectInfoRedacted {connectRedactedHost = "1", connectRedactedPort = 1, connectRedactedUser = "1", cnnectRedactedDatabase = "1"}
```

