### PR TITLE
Add support for Natural type in FromField and ToField instances

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -153,6 +153,7 @@ import           Data.UUID.Types   (UUID)
 import qualified Data.UUID.Types as UUID
 import           Data.Scientific (Scientific)
 import           GHC.Real (infinity, notANumber)
+import           GHC.Natural (Natural)
 
 import qualified Data.Aeson.Types as JSON
 
@@ -348,6 +349,10 @@ instance FromField Int64 where
 -- | int2, int4, int8
 instance FromField Integer where
     fromField = attoFieldParser ok64 $ signed decimal
+
+-- | int2, int4, int8 (non-negative only)
+instance FromField Natural where
+  fromField = attoFieldParser ok64 decimal
 
 -- | int2, float4    (Uses attoparsec's 'double' routine,  for
 --   better accuracy convert to 'Scientific' or 'Rational' first)

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -61,6 +61,7 @@ import           Database.PostgreSQL.Simple.Time
 import           Data.Scientific (Scientific)
 import           Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import           Foreign.C.Types (CUInt(..))
+import           GHC.Natural (Natural)
 
 -- | How to render an element when substituting it into a query.
 data Action =
@@ -158,6 +159,10 @@ instance ToField Int64 where
 
 instance ToField Integer where
     toField = Plain . integerDec
+    {-# INLINE toField #-}
+
+instance ToField Natural where
+    toField = Plain . integerDec . toInteger
     {-# INLINE toField #-}
 
 instance ToField Word8 where

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -48,6 +48,7 @@ import System.FilePath
 import System.Timeout(timeout)
 import Data.Time.Compat (getCurrentTime, diffUTCTime)
 import System.Environment (getEnvironment)
+import GHC.Natural (Natural)
 
 import Test.Tasty
 import Test.Tasty.Golden
@@ -86,6 +87,7 @@ tests env = testGroup "tests"
     , testCase "3-ary generic"        . testGeneric3
     , testCase "Timeout"              . testTimeout
     , testCase "Exceptions"           . testExceptions
+    , testCase "Natural"               . testNatural
     ]
 
 testBytea :: TestEnv -> TestTree
@@ -535,6 +537,23 @@ testDouble TestEnv{..} = do
     x @?= (1 / 0)
     [Only (x :: Double)] <- query_ conn "SELECT '-Infinity'::float8"
     x @?= (-1 / 0)
+
+
+testNatural :: TestEnv -> Assertion
+testNatural TestEnv{..} = do
+    -- round-trip zero and positive values via parameter substitution
+    roundTrip 0
+    roundTrip 1
+    roundTrip 12345678901234567890
+    -- selecting a negative value should fail for Natural
+    True <- expectError (\(_ :: SomeException) -> True) $
+      (query_ conn "SELECT (-1)::bigint" :: IO [Only Natural])
+    return ()
+  where
+    roundTrip :: Natural -> Assertion
+    roundTrip n = do
+      [Only n'] <- query conn "SELECT ?::bigint" (Only n)
+      n' @?= n
 
 
 testGeneric1 :: TestEnv -> Assertion


### PR DESCRIPTION
Hi,
This PR adds support for Natural type for Postgres.
This will come handy with web requests which expect a Natural (basically a non negative number) and then go on to use that request values to be inserted/updated into the postgres database

Let me know, if you need any changes or if you think this is not required.

Thanks