### PR TITLE
Fix typos

### DIFF
--- a/src/Database/PostgreSQL/Simple/Copy.hs
+++ b/src/Database/PostgreSQL/Simple/Copy.hs
@@ -66,7 +66,7 @@ copy conn template qs = do
 -- | Issue a @COPY FROM STDIN@ or @COPY TO STDOUT@ query.   In the former
 --   case, the connection's state will change to @CopyIn@;  in the latter,
 --   @CopyOut@.  The connection must be in the ready state in order
---   to call this function.  Does not perform parameter subsitution.
+--   to call this function.  Does not perform parameter substitution.
 
 copy_ :: Connection -> Query -> IO ()
 copy_ conn (Query q) = do

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -647,7 +647,7 @@ okInt = ok32
 okInt = ok64
 #endif
 
--- | eq and \/ are used to imlement what Macro stuff did,
+-- | eq and \/ are used to implement what Macro stuff did,
 -- i.e. mkCompats and inlineTypoid
 eq :: PQ.Oid -> PQ.Oid -> Bool
 eq = (==)

--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -625,7 +625,7 @@ escapeByteaConn = escapeWrap PQ.escapeByteaConn
 breakOnSingleQuestionMark :: ByteString -> (ByteString, ByteString)
 breakOnSingleQuestionMark b = go (B8.empty, b)
   where go (x,bs) = (x `B8.append` x',bs')
-                -- seperate from first QM
+                -- separate from first QM
           where tup@(noQ, restWithQ) = B8.break (=='?') bs
                 -- if end of query, just return
                 -- else check for second QM in 'go2'


### PR DESCRIPTION
Found via `codespell -L airpost,te,fo,copyin,ist,bu`